### PR TITLE
Added error message if no translation was found.

### DIFF
--- a/api/glosbe.cpp
+++ b/api/glosbe.cpp
@@ -71,7 +71,18 @@ void Glosbe::parseResult(QNetworkReply* reply)
             match.setRelevance(relevance);
             matches.append(match);
         }
-    }   
+    }
+
+    // Create error message if no translation was found
+    if (matches.isEmpty()) {
+        relevance -= 0.01;
+        Plasma::QueryMatch match(m_runner);
+        match.setType(Plasma::QueryMatch::NoMatch);
+        match.setIcon(QIcon::fromTheme("dialog-error"));
+        match.setText("No translation found");
+        match.setRelevance(relevance);
+        matches.append(match);
+    }
     m_context.addMatches(matches);
     emit(finished());
 }


### PR DESCRIPTION
This is helpful to provide some feedback to the user when he e.g. mistyped the word to translate.