### PR TITLE
Fix compiler warnings and deprecations, optimize build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,21 @@
 This is a plugin for Plasma 5 KRunner. It's a translator and it translates text. Currently [glosbe](https://glosbe.com/) and [yandex](https://www.yandex.ru/) are supported.
 
 ## Installation ##
+#### Required Dependencies
+Debian/Ubuntu:  
+`sudo apt install cmake extra-cmake-modules build-essential libkf5runner-dev libkf5textwidgets-dev qtdeclarative5-dev gettext`
+
+openSUSE  
+`sudo zypper install cmake extra-cmake-modules libQt5Widgets5 libQt5Core5 libqt5-qtlocation-devel ki18n-devel ktextwidgets-devel 
+kservice-devel krunner-devel gettext-tools kconfigwidgets-devel`
+
+Fedora  
+`sudo dnf install cmake extra-cmake-modules kf5-ki18n-devel kf5-kservice-devel kf5-krunner-devel kf5-ktextwidgets-devel gettext`
+
 ```
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=`kf5-config --prefix` -DKDE_INSTALL_QTPLUGINDIR=`kf5-config --qt-plugins`
+cmake .. -DCMAKE_INSTALL_PREFIX=`kf5-config --prefix` -DKDE_INSTALL_QTPLUGINDIR=`kf5-config --qt-plugins` -DCMAKE_BUILD_TYPE=Release
 make 
 sudo make install
 kquitapp5 krunner
@@ -32,7 +43,7 @@ Syntax: \<sourcelang\>-\<targetlang\> \<searchterm\>
 ### Use default source language ###
 Syntax: \<targetlang\> \<searchterm\>
 
-Defuault source language: *English (en)*  
+Default source language: *English (en)*  
 Alternative source language: *German (de)*  
 
 *de soccer* → *en-de soccer*  

--- a/api/glosbe.cpp
+++ b/api/glosbe.cpp
@@ -65,7 +65,7 @@ Glosbe::Glosbe(Plasma::AbstractRunner * runner, Plasma::RunnerContext& context, 
 
 void Glosbe::parseExamples(QNetworkReply* reply)
 {
-    QJsonObject jsonObject = QJsonDocument::fromJson(QString::fromUtf8(reply->readAll()).toUtf8()).object();
+    const QJsonObject jsonObject = QJsonDocument::fromJson(QString::fromUtf8(reply->readAll()).toUtf8()).object();
 
     if (jsonObject.value("result").toString() != "ok") {
         emit finished();
@@ -73,11 +73,11 @@ void Glosbe::parseExamples(QNetworkReply* reply)
     }
     
     QList<Plasma::QueryMatch> matches;
-    QJsonArray tuc = jsonObject.find("examples").value().toArray();
+    const QJsonArray tuc = jsonObject.find("examples").value().toArray();
     float relevance = 0.8;
-    foreach(const QJsonValue a, tuc) {
-       QString s = a.toObject().value("second").toString();
-       if (s.size() > 0) {
+    for(const auto& a: tuc) {
+       const QString s = a.toObject().value("second").toString();
+       if (!s.isEmpty()) {
            Plasma::QueryMatch match(m_runner);
            match.setType(Plasma::QueryMatch::InformationalMatch);
            match.setIcon(QIcon::fromTheme("server-database"));
@@ -103,18 +103,18 @@ void Glosbe::parseExamples(QNetworkReply* reply)
 
 void Glosbe::parseResult(QNetworkReply* reply)
 {
-    QJsonObject jsonObject = QJsonDocument::fromJson(QString::fromUtf8(reply->readAll()).toUtf8()).object();
+    const QJsonObject jsonObject = QJsonDocument::fromJson(QString::fromUtf8(reply->readAll()).toUtf8()).object();
     if (jsonObject.value("result").toString() != "ok") {
         emit finished();
         return;
     }
     
     QList<Plasma::QueryMatch> matches;
-    QJsonArray tuc = jsonObject.find("tuc").value().toArray();
+    const QJsonArray tuc = jsonObject.find("tuc").value().toArray();
     float relevance = 1;
-    foreach(QJsonValue a, tuc) {
-        QString s = a.toObject().value("phrase").toObject().value("text").toString();
-        if (s.size() > 0) {
+    for(const auto& a: tuc) {
+        const QString s = a.toObject().value("phrase").toObject().value("text").toString();
+        if (!s.isEmpty()) {
             relevance -= 0.01;
             Plasma::QueryMatch match(m_runner);
             match.setType(Plasma::QueryMatch::InformationalMatch);

--- a/api/yandex.cpp
+++ b/api/yandex.cpp
@@ -36,7 +36,6 @@ Yandex::Yandex(Plasma::AbstractRunner * runner, Plasma::RunnerContext& context, 
     QNetworkRequest request(QUrl("https://translate.yandex.net/api/v1.5/tr.json/translate?" + QUrl(query.query(QUrl::FullyEncoded).toUtf8()).toEncoded()));
     request.setSslConfiguration(QSslConfiguration::defaultConfiguration());
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
-    qDebug() << request.url().toString();
 
     m_manager -> get(request);
     connect(m_manager, SIGNAL(finished(QNetworkReply*)), this, SLOT(parseResult(QNetworkReply*)));
@@ -49,13 +48,13 @@ void Yandex::parseResult(QNetworkReply* reply)
         return;
     }
 
-    QString s = QString::fromUtf8(reply->readAll());
-    QJsonObject jsonObject = QJsonDocument::fromJson(s.toUtf8()).object();
+    const QString s = QString::fromUtf8(reply->readAll());
+    const QJsonObject jsonObject = QJsonDocument::fromJson(s.toUtf8()).object();
     
     QList<Plasma::QueryMatch> matches;
-    QJsonArray texts = jsonObject.find("text").value().toArray();
+    const QJsonArray texts = jsonObject.find("text").value().toArray();
     float relevance = 1;
-    foreach(QJsonValue text, texts) {
+    for(const auto& text: texts) {
         Plasma::QueryMatch match(m_runner);
             match.setType(Plasma::QueryMatch::InformationalMatch);
             match.setIcon(QIcon::fromTheme("applications-education-language"));

--- a/config/translator_config.cpp
+++ b/config/translator_config.cpp
@@ -51,8 +51,6 @@ TranslatorConfig::TranslatorConfig(QWidget* parent, const QVariantList& args) :
     connect(m_ui->glosbe_word, SIGNAL(stateChanged(int)),this,SLOT(changed()));
     connect(m_ui->glosbe_phrase, SIGNAL(stateChanged(int)),this,SLOT(changed()));
     connect(m_ui->glosbe_examples, SIGNAL(stateChanged(int)),this,SLOT(changed()));
-    
-    load();
 }
 
 void TranslatorConfig::load()

--- a/config/translator_config.h
+++ b/config/translator_config.h
@@ -44,11 +44,11 @@ class TranslatorConfig : public KCModule
     Q_OBJECT
 
 public:
-    explicit TranslatorConfig(QWidget* parent = 0, const QVariantList& args = QVariantList());
+    explicit TranslatorConfig(QWidget* parent = nullptr, const QVariantList& args = QVariantList());
     
 public Q_SLOTS:
-    void save();
-    void load();
+    void save() override;
+    void load() override;
 
 private:
     TranslatorConfigForm* m_ui;

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p build
+cd build
+
+cmake .. -DCMAKE_INSTALL_PREFIX=`kf5-config --prefix` -DKDE_INSTALL_QTPLUGINDIR=`kf5-config --qt-plugins` -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+
+sudo make install
+
+kquitapp5 krunner 2> /dev/null
+kstart5 --windowclass krunner krunner > /dev/null 2>&1 &

--- a/translator.cpp
+++ b/translator.cpp
@@ -48,12 +48,12 @@ bool Translator::parseTerm(const QString& term, QString& text, QPair<QString, QS
     const int index = term.indexOf(" ");
     if (index == -1) return false;
     text = term.mid(index + 1);
-    QString languageTerm = term.left(index);
+    const QString languageTerm = term.left(index);
 
     if (languageTerm.contains("-")) {
-        int index = languageTerm.indexOf("-");
-        language.first = languageTerm.left(index);
-        language.second = languageTerm.mid(index + 1);
+        int languageIndex = languageTerm.indexOf("-");
+        language.first = languageTerm.left(languageIndex);
+        language.second = languageTerm.mid(languageIndex + 1);
 
     } else {
         if (m_primary == languageTerm) {
@@ -72,11 +72,9 @@ void Translator::match(Plasma::RunnerContext &context)
     QString text;
     QPair<QString, QString> language;
 
-    qDebug() << "hallo" << endl;
-    
     if (!parseTerm(term, text, language)) return;
     if (!context.isValid()) return;
-    
+
     if (text.contains(" ")) {
         if(m_yandexPhrase) {
             QEventLoop loop;


### PR DESCRIPTION
Hello,

I have made some changes to your project:
- The build is now a release type and not debug, consequently the compiler does more optimizations and the output files are significantly smaller.
- The compiler warnings have been fixed
- The deprecated Q_FOREACH macro has been refactored
- An install script has been added
- Commands to install the required dependencies have been added to the README.md