### PR TITLE
Add GitHub Actions workflows to build and publish RPM/DEB packages

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -6,6 +6,9 @@ on:
       distro:
         required: true
         type: string
+      package_version:
+        required: false
+        type: string
       docker_image:
         required: true
         type: string
@@ -64,7 +67,17 @@ jobs:
             translate-shell rpm-build
 
       - name: Configure
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+        run: |
+          PACKAGE_VERSION="${{ inputs.package_version }}"
+          if [ -z "$PACKAGE_VERSION" ]; then
+            PACKAGE_VERSION="${GITHUB_REF_NAME#v}"
+          else
+            PACKAGE_VERSION="${PACKAGE_VERSION#v}"
+          fi
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPACKAGE_DISTRO=${{ inputs.distro }} \
+            -DPACKAGE_VERSION="$PACKAGE_VERSION"
 
       - name: Build
         run: cmake --build build --parallel

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -72,7 +72,10 @@ jobs:
       - name: Collect package
         run: |
           mkdir -p dist
-          find build/ -maxdepth 1 \( -name "*.deb" -o -name "*.rpm" \) -exec cp {} dist/ \;
+          find build/ -maxdepth 1 \( -name "*.deb" -o -name "*.rpm" \) | while read f; do
+            ext="${f##*.}"
+            cp "$f" "dist/krunner-translator-${{ inputs.distro }}.$ext"
+          done
           echo "Packages found:"
           ls -lh dist/
 

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,0 +1,84 @@
+name: Build Package
+
+on:
+  workflow_call:
+    inputs:
+      distro:
+        required: true
+        type: string
+      docker_image:
+        required: true
+        type: string
+      pkg_manager:
+        required: true
+        type: string
+      cpack_gen:
+        required: true
+        type: string
+      artifact_ext:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.docker_image }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies (apt)
+        if: ${{ inputs.pkg_manager == 'apt' }}
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential cmake extra-cmake-modules \
+            qt6-base-dev libkf6runner-dev libkf6i18n-dev \
+            libkf6coreaddons-dev libkf6config-dev \
+            libkf6configwidgets-dev libkf6kcmutils-dev \
+            translate-shell dpkg-dev
+
+      - name: Install build dependencies (dnf)
+        if: ${{ inputs.pkg_manager == 'dnf' }}
+        run: |
+          dnf install -y \
+            gcc-c++ cmake extra-cmake-modules \
+            qt6-qtbase-devel kf6-krunner-devel kf6-ki18n-devel \
+            kf6-kcoreaddons-devel kf6-kconfig-devel \
+            kf6-kconfigwidgets-devel kf6-kkcmutils-devel \
+            translate-shell rpm-build
+
+      - name: Install build dependencies (zypper)
+        if: ${{ inputs.pkg_manager == 'zypper' }}
+        run: |
+          zypper --non-interactive refresh
+          zypper --non-interactive install \
+            gcc-c++ cmake extra-cmake-modules \
+            qt6-base-devel kf6-krunner-devel kf6-ki18n-devel \
+            kf6-kcoreaddons-devel kf6-kconfig-devel \
+            kf6-kconfigwidgets-devel kf6-kkcmutils-devel \
+            translate-shell rpm-build
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Package
+        run: cd build && cpack -G ${{ inputs.cpack_gen }}
+
+      - name: Collect package
+        run: |
+          mkdir -p dist
+          find build/ -maxdepth 1 \( -name "*.deb" -o -name "*.rpm" \) -exec cp {} dist/ \;
+          echo "Packages found:"
+          ls -lh dist/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-${{ inputs.distro }}
+          path: dist/
+          if-no-files-found: error

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -15,10 +15,16 @@ on:
       cpack_gen:
         required: true
         type: string
+      runner:
+        required: true
+        type: string
+      arch:
+        required: true
+        type: string
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     container:
       image: ${{ inputs.docker_image }}
 
@@ -71,7 +77,7 @@ jobs:
           mkdir -p dist
           find build/ -maxdepth 1 \( -name "*.deb" -o -name "*.rpm" \) | while read f; do
             ext="${f##*.}"
-            cp "$f" "dist/krunner-translator-${{ inputs.distro }}.$ext"
+            cp "$f" "dist/krunner-translator-${{ inputs.distro }}-${{ inputs.arch }}.$ext"
           done
           echo "Packages found:"
           ls -lh dist/
@@ -79,6 +85,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: package-${{ inputs.distro }}
+          name: package-${{ inputs.distro }}-${{ inputs.arch }}
           path: dist/
           if-no-files-found: error

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -40,7 +40,7 @@ jobs:
             qt6-base-dev libkf6runner-dev libkf6i18n-dev \
             libkf6coreaddons-dev libkf6config-dev \
             libkf6configwidgets-dev libkf6kcmutils-dev \
-            translate-shell dpkg-dev
+            dpkg-dev
 
       - name: Install build dependencies (dnf)
         if: ${{ inputs.pkg_manager == 'dnf' }}

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -15,9 +15,6 @@ on:
       cpack_gen:
         required: true
         type: string
-      artifact_ext:
-        required: true
-        type: string
 
 jobs:
   build:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -46,7 +46,7 @@ jobs:
             gcc-c++ cmake extra-cmake-modules \
             qt6-qtbase-devel kf6-krunner-devel kf6-ki18n-devel \
             kf6-kcoreaddons-devel kf6-kconfig-devel \
-            kf6-kconfigwidgets-devel kf6-kkcmutils-devel \
+            kf6-kconfigwidgets-devel kf6-kcmutils-devel \
             translate-shell rpm-build
 
       - name: Install build dependencies (zypper)
@@ -54,10 +54,10 @@ jobs:
         run: |
           zypper --non-interactive refresh
           zypper --non-interactive install \
-            gcc-c++ cmake extra-cmake-modules \
+            gcc-c++ cmake kf6-extra-cmake-modules \
             qt6-base-devel kf6-krunner-devel kf6-ki18n-devel \
             kf6-kcoreaddons-devel kf6-kconfig-devel \
-            kf6-kconfigwidgets-devel kf6-kkcmutils-devel \
+            kf6-kconfigwidgets-devel kf6-kcmutils-devel \
             translate-shell rpm-build
 
       - name: Configure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     uses: ./.github/workflows/build-package.yml
     with:
       distro: ubuntu
+      package_version: ${{ github.event.inputs.tag }}
       docker_image: ubuntu:25.04
       pkg_manager: apt
       cpack_gen: DEB
@@ -26,6 +27,7 @@ jobs:
     uses: ./.github/workflows/build-package.yml
     with:
       distro: fedora
+      package_version: ${{ github.event.inputs.tag }}
       docker_image: fedora:42
       pkg_manager: dnf
       cpack_gen: RPM
@@ -36,6 +38,7 @@ jobs:
     uses: ./.github/workflows/build-package.yml
     with:
       distro: opensuse
+      package_version: ${{ github.event.inputs.tag }}
       docker_image: opensuse/tumbleweed
       pkg_manager: zypper
       cpack_gen: RPM
@@ -46,6 +49,7 @@ jobs:
     uses: ./.github/workflows/build-package.yml
     with:
       distro: ubuntu
+      package_version: ${{ github.event.inputs.tag }}
       docker_image: ubuntu:25.04
       pkg_manager: apt
       cpack_gen: DEB
@@ -56,6 +60,7 @@ jobs:
     uses: ./.github/workflows/build-package.yml
     with:
       distro: fedora
+      package_version: ${{ github.event.inputs.tag }}
       docker_image: fedora:42
       pkg_manager: dnf
       cpack_gen: RPM
@@ -66,6 +71,7 @@ jobs:
     uses: ./.github/workflows/build-package.yml
     with:
       distro: opensuse
+      package_version: ${{ github.event.inputs.tag }}
       docker_image: opensuse/tumbleweed
       pkg_manager: zypper
       cpack_gen: RPM
@@ -76,6 +82,7 @@ jobs:
     uses: ./.github/workflows/build-package.yml
     with:
       distro: debian
+      package_version: ${{ github.event.inputs.tag }}
       docker_image: debian:trixie
       pkg_manager: apt
       cpack_gen: DEB
@@ -86,6 +93,7 @@ jobs:
     uses: ./.github/workflows/build-package.yml
     with:
       distro: debian
+      package_version: ${{ github.event.inputs.tag }}
       docker_image: debian:trixie
       pkg_manager: apt
       cpack_gen: DEB

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,24 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Determine tag name
         id: tag
         run: |
           TAG="${{ github.event.inputs.tag }}"
           if [ -z "$TAG" ]; then
             TAG="${{ github.ref_name }}"
+          fi
+          # If still not a version tag (e.g. triggered manually on a branch), use latest git tag
+          if [[ "$TAG" != v*.*.* ]]; then
+            TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          fi
+          if [ -z "$TAG" ]; then
+            echo "ERROR: No version tag found. Pass a tag input (e.g. v2.0.0) when using workflow_dispatch." >&2
+            exit 1
           fi
           echo "name=$TAG" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release Packages
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to attach packages to (e.g. v2.0.0). Leave empty to use current ref.'
+        required: false
+        type: string
+
+jobs:
+  build-ubuntu:
+    uses: ./.github/workflows/build-package.yml
+    with:
+      distro: ubuntu
+      docker_image: ubuntu:25.04
+      pkg_manager: apt
+      cpack_gen: DEB
+      artifact_ext: deb
+
+  build-fedora:
+    uses: ./.github/workflows/build-package.yml
+    with:
+      distro: fedora
+      docker_image: fedora:42
+      pkg_manager: dnf
+      cpack_gen: RPM
+      artifact_ext: rpm
+
+  build-opensuse:
+    uses: ./.github/workflows/build-package.yml
+    with:
+      distro: opensuse
+      docker_image: opensuse/tumbleweed
+      pkg_manager: zypper
+      cpack_gen: RPM
+      artifact_ext: rpm
+
+  release:
+    needs: [build-ubuntu, build-fedora, build-opensuse]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Determine tag name
+        id: tag
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="${{ github.ref_name }}"
+          fi
+          echo "name=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Download all packages
+        uses: actions/download-artifact@v4
+        with:
+          path: packages/
+          merge-multiple: true
+
+      - name: List downloaded packages
+        run: find packages/ -type f
+
+      - name: Create or update GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          draft: ${{ github.event_name == 'workflow_dispatch' }}
+          files: packages/*
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,26 @@ jobs:
       runner: ubuntu-24.04-arm
       arch: arm64
 
+  build-debian:
+    uses: ./.github/workflows/build-package.yml
+    with:
+      distro: debian
+      docker_image: debian:trixie
+      pkg_manager: apt
+      cpack_gen: DEB
+      runner: ubuntu-latest
+      arch: amd64
+
+  build-debian-arm64:
+    uses: ./.github/workflows/build-package.yml
+    with:
+      distro: debian
+      docker_image: debian:trixie
+      pkg_manager: apt
+      cpack_gen: DEB
+      runner: ubuntu-24.04-arm
+      arch: arm64
+
   validate-ubuntu:
     needs: build-ubuntu
     uses: ./.github/workflows/validate-package.yml
@@ -132,8 +152,28 @@ jobs:
       runner: ubuntu-24.04-arm
       arch: arm64
 
+  validate-debian:
+    needs: build-debian
+    uses: ./.github/workflows/validate-package.yml
+    with:
+      distro: debian
+      docker_image: debian:trixie
+      pkg_manager: apt
+      runner: ubuntu-latest
+      arch: amd64
+
+  validate-debian-arm64:
+    needs: build-debian-arm64
+    uses: ./.github/workflows/validate-package.yml
+    with:
+      distro: debian
+      docker_image: debian:trixie
+      pkg_manager: apt
+      runner: ubuntu-24.04-arm
+      arch: arm64
+
   release:
-    needs: [validate-ubuntu, validate-fedora, validate-opensuse, validate-ubuntu-arm64, validate-fedora-arm64, validate-opensuse-arm64]
+    needs: [validate-ubuntu, validate-fedora, validate-opensuse, validate-ubuntu-arm64, validate-fedora-arm64, validate-opensuse-arm64, validate-debian, validate-debian-arm64]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
       docker_image: ubuntu:25.04
       pkg_manager: apt
       cpack_gen: DEB
-      artifact_ext: deb
 
   build-fedora:
     uses: ./.github/workflows/build-package.yml
@@ -28,7 +27,6 @@ jobs:
       docker_image: fedora:42
       pkg_manager: dnf
       cpack_gen: RPM
-      artifact_ext: rpm
 
   build-opensuse:
     uses: ./.github/workflows/build-package.yml
@@ -37,7 +35,6 @@ jobs:
       docker_image: opensuse/tumbleweed
       pkg_manager: zypper
       cpack_gen: RPM
-      artifact_ext: rpm
 
   release:
     needs: [build-ubuntu, build-fedora, build-opensuse]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
       docker_image: ubuntu:25.04
       pkg_manager: apt
       cpack_gen: DEB
+      runner: ubuntu-latest
+      arch: amd64
 
   build-fedora:
     uses: ./.github/workflows/build-package.yml
@@ -27,6 +29,8 @@ jobs:
       docker_image: fedora:42
       pkg_manager: dnf
       cpack_gen: RPM
+      runner: ubuntu-latest
+      arch: amd64
 
   build-opensuse:
     uses: ./.github/workflows/build-package.yml
@@ -35,9 +39,41 @@ jobs:
       docker_image: opensuse/tumbleweed
       pkg_manager: zypper
       cpack_gen: RPM
+      runner: ubuntu-latest
+      arch: amd64
+
+  build-ubuntu-arm64:
+    uses: ./.github/workflows/build-package.yml
+    with:
+      distro: ubuntu
+      docker_image: ubuntu:25.04
+      pkg_manager: apt
+      cpack_gen: DEB
+      runner: ubuntu-24.04-arm
+      arch: arm64
+
+  build-fedora-arm64:
+    uses: ./.github/workflows/build-package.yml
+    with:
+      distro: fedora
+      docker_image: fedora:42
+      pkg_manager: dnf
+      cpack_gen: RPM
+      runner: ubuntu-24.04-arm
+      arch: arm64
+
+  build-opensuse-arm64:
+    uses: ./.github/workflows/build-package.yml
+    with:
+      distro: opensuse
+      docker_image: opensuse/tumbleweed
+      pkg_manager: zypper
+      cpack_gen: RPM
+      runner: ubuntu-24.04-arm
+      arch: arm64
 
   release:
-    needs: [build-ubuntu, build-fedora, build-opensuse]
+    needs: [build-ubuntu, build-fedora, build-opensuse, build-ubuntu-arm64, build-fedora-arm64, build-opensuse-arm64]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,68 @@ jobs:
       runner: ubuntu-24.04-arm
       arch: arm64
 
+  validate-ubuntu:
+    needs: build-ubuntu
+    uses: ./.github/workflows/validate-package.yml
+    with:
+      distro: ubuntu
+      docker_image: ubuntu:25.04
+      pkg_manager: apt
+      runner: ubuntu-latest
+      arch: amd64
+
+  validate-fedora:
+    needs: build-fedora
+    uses: ./.github/workflows/validate-package.yml
+    with:
+      distro: fedora
+      docker_image: fedora:42
+      pkg_manager: dnf
+      runner: ubuntu-latest
+      arch: amd64
+
+  validate-opensuse:
+    needs: build-opensuse
+    uses: ./.github/workflows/validate-package.yml
+    with:
+      distro: opensuse
+      docker_image: opensuse/tumbleweed
+      pkg_manager: zypper
+      runner: ubuntu-latest
+      arch: amd64
+
+  validate-ubuntu-arm64:
+    needs: build-ubuntu-arm64
+    uses: ./.github/workflows/validate-package.yml
+    with:
+      distro: ubuntu
+      docker_image: ubuntu:25.04
+      pkg_manager: apt
+      runner: ubuntu-24.04-arm
+      arch: arm64
+
+  validate-fedora-arm64:
+    needs: build-fedora-arm64
+    uses: ./.github/workflows/validate-package.yml
+    with:
+      distro: fedora
+      docker_image: fedora:42
+      pkg_manager: dnf
+      runner: ubuntu-24.04-arm
+      arch: arm64
+
+  validate-opensuse-arm64:
+    needs: build-opensuse-arm64
+    uses: ./.github/workflows/validate-package.yml
+    with:
+      distro: opensuse
+      docker_image: opensuse/tumbleweed
+      pkg_manager: zypper
+      runner: ubuntu-24.04-arm
+      arch: arm64
+
   release:
-    needs: [build-ubuntu, build-fedora, build-opensuse, build-ubuntu-arm64, build-fedora-arm64, build-opensuse-arm64]
+    needs: [validate-ubuntu, validate-fedora, validate-opensuse, validate-ubuntu-arm64, validate-fedora-arm64, validate-opensuse-arm64]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/validate-package.yml
+++ b/.github/workflows/validate-package.yml
@@ -1,0 +1,73 @@
+name: Validate Package
+
+on:
+  workflow_call:
+    inputs:
+      distro:
+        required: true
+        type: string
+      docker_image:
+        required: true
+        type: string
+      pkg_manager:
+        required: true
+        type: string
+      runner:
+        required: true
+        type: string
+      arch:
+        required: true
+        type: string
+
+jobs:
+  validate:
+    runs-on: ${{ inputs.runner }}
+    container:
+      image: ${{ inputs.docker_image }}
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: package-${{ inputs.distro }}-${{ inputs.arch }}
+          path: dist/
+
+      - name: Install package (apt)
+        if: ${{ inputs.pkg_manager == 'apt' }}
+        run: |
+          apt-get update
+          apt-get install -y ./dist/krunner-translator-${{ inputs.distro }}-${{ inputs.arch }}.deb
+
+      - name: Install package (dnf)
+        if: ${{ inputs.pkg_manager == 'dnf' }}
+        run: |
+          dnf install -y ./dist/krunner-translator-${{ inputs.distro }}-${{ inputs.arch }}.rpm
+
+      - name: Install package (zypper)
+        if: ${{ inputs.pkg_manager == 'zypper' }}
+        run: |
+          zypper --non-interactive --no-gpg-checks install ./dist/krunner-translator-${{ inputs.distro }}-${{ inputs.arch }}.rpm
+
+      - name: Verify install paths and shared libs
+        run: |
+          RUNNER_SO=$(find /usr -name "krunner_translator.so" 2>/dev/null)
+          KCM_SO=$(find /usr -name "kcm_krunner_translator.so" 2>/dev/null)
+
+          [ -n "$RUNNER_SO" ] || { echo "ERROR: krunner_translator.so not found"; exit 1; }
+          [ -n "$KCM_SO" ]    || { echo "ERROR: kcm_krunner_translator.so not found"; exit 1; }
+
+          echo "krunner_translator.so  -> $RUNNER_SO"
+          echo "kcm_krunner_translator.so -> $KCM_SO"
+
+          echo "$RUNNER_SO" | grep -q "kf6/krunner"      || { echo "ERROR: krunner_translator.so not in kf6/krunner path"; exit 1; }
+          echo "$KCM_SO"    | grep -q "kf6/krunner/kcms" || { echo "ERROR: kcm_krunner_translator.so not in kf6/krunner/kcms path"; exit 1; }
+
+          echo "--- ldd: krunner_translator.so ---"
+          ldd "$RUNNER_SO"
+          echo "--- ldd: kcm_krunner_translator.so ---"
+          ldd "$KCM_SO"
+
+          ldd "$RUNNER_SO" | grep -q "not found" && { echo "ERROR: missing shared libs in krunner_translator.so"; exit 1; } || true
+          ldd "$KCM_SO"    | grep -q "not found" && { echo "ERROR: missing shared libs in kcm_krunner_translator.so"; exit 1; } || true
+
+          echo "All checks passed."

--- a/.github/workflows/validate-package.yml
+++ b/.github/workflows/validate-package.yml
@@ -48,6 +48,10 @@ jobs:
         run: |
           zypper --non-interactive --no-gpg-checks install ./dist/krunner-translator-${{ inputs.distro }}-${{ inputs.arch }}.rpm
 
+      - name: Install validation tools (zypper)
+        if: ${{ inputs.pkg_manager == 'zypper' }}
+        run: zypper --non-interactive install -y findutils
+
       - name: Verify install paths and shared libs
         run: |
           RUNNER_SO=$(find /usr -name "krunner_translator.so" 2>/dev/null)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,10 @@ target_link_libraries(translator_test PRIVATE Qt6::Test)
 
 # ── Packaging (CPack) ──────────────────────────────────────────────────────────
 set(CPACK_PACKAGE_NAME "krunner-translator")
-# NOTE: When bumping the version, also update "Version" in src/plasma-runner-translator.json
-set(CPACK_PACKAGE_VERSION "2.0.0")
+# Keep the default in sync with "Version" in src/plasma-runner-translator.json for local/manual builds.
+set(PACKAGE_VERSION "2.0.0" CACHE STRING "Package version for CPack")
+set(PACKAGE_DISTRO "" CACHE STRING "Target distro for packaging metadata")
+set(CPACK_PACKAGE_VERSION "${PACKAGE_VERSION}")
 set(CPACK_PACKAGE_CONTACT "David Baum <david.baum@naraesk.eu>")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "KRunner plugin to translate text using multiple engines")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/naraesk/krunner-translator")
@@ -86,11 +88,14 @@ set(CPACK_STRIP_FILES TRUE)
 
 # DEB (Ubuntu 25.04 / Debian Trixie package names)
 # Qt6 runtime libs are intentionally omitted — they are pulled in transitively by the KF6 packages
-# translate-shell is in Recommends (not Depends): only needed for Google/Bing engines,
-# and is absent from Debian Trixie repos (install manually via https://github.com/soimort/translate-shell)
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
     "libkf6runner6, libkf6i18n6, libkf6configwidgets6, libkf6kcmutils6")
-set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "translate-shell")
+if(PACKAGE_DISTRO STREQUAL "ubuntu")
+    string(APPEND CPACK_DEBIAN_PACKAGE_DEPENDS ", translate-shell")
+elseif(PACKAGE_DISTRO STREQUAL "debian")
+    # Debian Trixie ships translate-shell in contrib, which is not enabled in stock sources.
+    set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "translate-shell")
+endif()
 set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
 
 # RPM (Fedora package names; openSUSE Tumbleweed uses same names)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ set(CPACK_STRIP_FILES TRUE)
 
 # DEB (Ubuntu 25.04 package names)
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "libkf6runner6, libkf6i18n6, libkf6configwidgets6t64, libkf6kcmutils6, libqt6widgets6, libqt6network6, translate-shell")
+    "libkf6runner6, libkf6i18n6, libkf6configwidgets6, libkf6kcmutils6, libqt6widgets6, libqt6network6, translate-shell")
 set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
 set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,10 +84,13 @@ set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/naraesk/krunner-translator")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/COPYING")
 set(CPACK_STRIP_FILES TRUE)
 
-# DEB (Ubuntu 25.04 package names)
+# DEB (Ubuntu 25.04 / Debian Trixie package names)
 # Qt6 runtime libs are intentionally omitted — they are pulled in transitively by the KF6 packages
+# translate-shell is in Recommends (not Depends): only needed for Google/Bing engines,
+# and is absent from Debian Trixie repos (install manually via https://github.com/soimort/translate-shell)
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "libkf6runner6, libkf6i18n6, libkf6configwidgets6, libkf6kcmutils6, translate-shell")
+    "libkf6runner6, libkf6i18n6, libkf6configwidgets6, libkf6kcmutils6")
+set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "translate-shell")
 set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
 
 # RPM (Fedora package names; openSUSE Tumbleweed uses same names)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(translator_test PRIVATE Qt6::Test)
 
 # ── Packaging (CPack) ──────────────────────────────────────────────────────────
 set(CPACK_PACKAGE_NAME "krunner-translator")
+# NOTE: When bumping the version, also update "Version" in src/plasma-runner-translator.json
 set(CPACK_PACKAGE_VERSION "2.0.0")
 set(CPACK_PACKAGE_CONTACT "David Baum <david.baum@naraesk.eu>")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "KRunner plugin to translate text using multiple engines")
@@ -87,7 +88,6 @@ set(CPACK_STRIP_FILES TRUE)
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
     "libkf6runner6, libkf6i18n6, libkf6configwidgets6, libkf6kcmutils6, libqt6widgets6, libqt6network6, translate-shell")
 set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
-set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
 
 # RPM (Fedora package names; openSUSE Tumbleweed uses same names)
 set(CPACK_RPM_PACKAGE_REQUIRES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
 
 # RPM (Fedora package names; openSUSE Tumbleweed uses same names)
 set(CPACK_RPM_PACKAGE_REQUIRES
-    "kf6-krunner, kf6-ki18n, kf6-kconfigwidgets, kf6-kcmutils, qt6-qtbase, translate-shell")
+    "kf6-krunner, kf6-ki18n, kf6-kconfigwidgets, kf6-kcmutils, translate-shell")
 set(CPACK_RPM_PACKAGE_LICENSE "GPL-3.0")
 set(CPACK_RPM_PACKAGE_GROUP "Applications/Utilities")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
 
 # RPM (Fedora package names; openSUSE Tumbleweed uses same names)
 set(CPACK_RPM_PACKAGE_REQUIRES
-    "kf6-krunner, kf6-ki18n, kf6-kconfigwidgets, kf6-kkcmutils, qt6-qtbase, translate-shell")
+    "kf6-krunner, kf6-ki18n, kf6-kconfigwidgets, kf6-kcmutils, qt6-qtbase, translate-shell")
 set(CPACK_RPM_PACKAGE_LICENSE "GPL-3.0")
 set(CPACK_RPM_PACKAGE_GROUP "Applications/Utilities")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,3 +73,26 @@ add_executable(translator_test test/TranslateShellProcessTest.cpp ${test_depende
 add_test(NAME translator_test COMMAND translator_test)
 
 target_link_libraries(translator_test PRIVATE Qt6::Test)
+
+# ── Packaging (CPack) ──────────────────────────────────────────────────────────
+set(CPACK_PACKAGE_NAME "krunner-translator")
+set(CPACK_PACKAGE_VERSION "2.0.0")
+set(CPACK_PACKAGE_CONTACT "David Baum <david.baum@naraesk.eu>")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "KRunner plugin to translate text using multiple engines")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/naraesk/krunner-translator")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/COPYING")
+set(CPACK_STRIP_FILES TRUE)
+
+# DEB (Ubuntu 25.04 package names)
+set(CPACK_DEBIAN_PACKAGE_DEPENDS
+    "libkf6runner6, libkf6i18n6, libkf6configwidgets6t64, libkf6kcmutils6, libqt6widgets6, libqt6network6, translate-shell")
+set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+
+# RPM (Fedora package names; openSUSE Tumbleweed uses same names)
+set(CPACK_RPM_PACKAGE_REQUIRES
+    "kf6-krunner, kf6-ki18n, kf6-kconfigwidgets, kf6-kkcmutils, qt6-qtbase, translate-shell")
+set(CPACK_RPM_PACKAGE_LICENSE "GPL-3.0")
+set(CPACK_RPM_PACKAGE_GROUP "Applications/Utilities")
+
+include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,9 @@ set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/COPYING")
 set(CPACK_STRIP_FILES TRUE)
 
 # DEB (Ubuntu 25.04 package names)
+# Qt6 runtime libs are intentionally omitted — they are pulled in transitively by the KF6 packages
 set(CPACK_DEBIAN_PACKAGE_DEPENDS
-    "libkf6runner6, libkf6i18n6, libkf6configwidgets6, libkf6kcmutils6, libqt6widgets6, libqt6network6, translate-shell")
+    "libkf6runner6, libkf6i18n6, libkf6configwidgets6, libkf6kcmutils6, translate-shell")
 set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
 
 # RPM (Fedora package names; openSUSE Tumbleweed uses same names)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,54 @@ This is a plugin for Plasma 6 KRunner. It's a translator and it translates text.
 
 [![Logo Arch Linux](../../wiki/logos/arch_linux.png)](https://aur.archlinux.org/packages/plasma6-runners-translator)
 
-Pre-built packages for recent distro releases (ubuntu, fedora, opensuse) are available on the [GitHub Releases page](https://github.com/naraesk/krunner-translator/releases).
+Pre-built packages for recent distro releases (ubuntu, debian, fedora, opensuse) are available on the [GitHub Releases page](https://github.com/naraesk/krunner-translator/releases).
+
+## Install Packages
+
+`translate-shell` is required for the default Google engine, Bing, and audio playback.
+
+### Ubuntu 25.04+
+
+`translate-shell` is packaged in Ubuntu `multiverse`. Ubuntu usually enables this by default, but enabling it explicitly keeps package installs reliable:
+
+```sh
+sudo add-apt-repository multiverse
+sudo apt update
+sudo apt install ./krunner-translator-ubuntu-amd64.deb
+```
+
+Replace the file name with the package you downloaded from the release page.
+
+### Debian trixie
+
+The plugin package installs directly, but `translate-shell` is only available from Debian `contrib`, which is not enabled in stock sources. If you want Google/Bing/audio support, enable `contrib` first and then install the package:
+
+```sh
+sudo editor /etc/apt/sources.list.d/debian.sources
+```
+
+Add `contrib` to each `Components:` line, then run:
+
+```sh
+sudo apt update
+sudo apt install ./krunner-translator-debian-amd64.deb
+```
+
+See the Debian sources format reference for the exact file structure: <https://wiki.debian.org/SourcesList>
+
+### Fedora 42
+
+```sh
+sudo dnf install ./krunner-translator-fedora-amd64.rpm
+```
+
+### openSUSE Tumbleweed
+
+```sh
+sudo zypper install ./krunner-translator-opensuse-amd64.rpm
+```
+
+Replace the file names above with the package matching your distro and architecture.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Pre-built packages for recent distro releases (ubuntu, debian, fedora, opensuse)
 
 ## Install Packages
 
-`translate-shell` is required for the default Google engine, Bing, and audio playback.
+`translate-shell` is required for the default key-less Google engine, Bing, and audio playback.
 
 ### Ubuntu 25.04+
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ translate-shell build-essential cmake extra-cmake-modules qt6-base-dev libkf6run
 translate-shell cmake extra-cmake-modules cmake(Qt6Core) cmake(Qt6Gui) cmake(Qt6Widgets) cmake(Qt6Network) cmake(KF6Runner) cmake(KF6I18n) cmake(KF6CoreAddons) cmake(KF6Config) cmake(KF6ConfigWidgets) cmake(KF6KCMUtils)
 ```
 
+## Pre-built packages
+
+Pre-built packages for recent distro releases are available on the [GitHub Releases page](https://github.com/naraesk/krunner-translator/releases).
+
+**Ubuntu 25.04:**
+```sh
+sudo dpkg -i krunner-translator-ubuntu.deb
+```
+
+**Fedora 42:**
+```sh
+sudo dnf install ./krunner-translator-fedora.rpm
+```
+
+**openSUSE Tumbleweed** (package is unsigned):
+```sh
+sudo zypper --no-gpg-checks install ./krunner-translator-opensuse.rpm
+```
+
 ## Configuration
 
 For being able to use Youdao and Baidu, an API key is required. You have to obtain a key yourself by following these steps:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a plugin for Plasma 6 KRunner. It's a translator and it translates text.
 ## Packages
 
 [![Logo Arch Linux](../../wiki/logos/arch_linux.png)](https://aur.archlinux.org/packages/plasma6-runners-translator)
+Pre-built packages for recent distro releases (ubuntu, fedora, opensuse) are available on the [GitHub Releases page](https://github.com/naraesk/krunner-translator/releases).
 
 ## Building from source
 
@@ -41,25 +42,6 @@ translate-shell build-essential cmake extra-cmake-modules qt6-base-dev libkf6run
 
 ```
 translate-shell cmake extra-cmake-modules cmake(Qt6Core) cmake(Qt6Gui) cmake(Qt6Widgets) cmake(Qt6Network) cmake(KF6Runner) cmake(KF6I18n) cmake(KF6CoreAddons) cmake(KF6Config) cmake(KF6ConfigWidgets) cmake(KF6KCMUtils)
-```
-
-## Pre-built packages
-
-Pre-built packages for recent distro releases are available on the [GitHub Releases page](https://github.com/naraesk/krunner-translator/releases).
-
-**Ubuntu 25.04:**
-```sh
-sudo dpkg -i krunner-translator-ubuntu.deb
-```
-
-**Fedora 42:**
-```sh
-sudo dnf install ./krunner-translator-fedora.rpm
-```
-
-**openSUSE Tumbleweed** (package is unsigned):
-```sh
-sudo zypper --no-gpg-checks install ./krunner-translator-opensuse.rpm
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a plugin for Plasma 6 KRunner. It's a translator and it translates text.
 ## Packages
 
 [![Logo Arch Linux](../../wiki/logos/arch_linux.png)](https://aur.archlinux.org/packages/plasma6-runners-translator)
+
 Pre-built packages for recent distro releases (ubuntu, fedora, opensuse) are available on the [GitHub Releases page](https://github.com/naraesk/krunner-translator/releases).
 
 ## Building from source


### PR DESCRIPTION
This PR was created by claude code on my behalf. I actively monitored it and ensured result is ok, produced package works on my local fedora

Text below is AI generated

---

## Summary

- Adds CPack configuration to \`CMakeLists.txt\` to generate \`.deb\` and \`.rpm\` packages
- Adds a reusable \`build-package.yml\` workflow that builds in distro-native Docker containers (amd64 + arm64)
- Adds a \`release.yml\` orchestrator triggered on \`v*.*.*\` tag pushes or manual dispatch (\`workflow_dispatch\`)
- Adds a \`validate.yml\` workflow that installs each built package and verifies file paths and shared library linkage (\`ldd\`)

## Supported distributions

| Distro | Format | Architectures | Notes |
|--------|--------|---------------|-------|
| Ubuntu 25.04 (Plucky) | \`.deb\` | amd64, arm64 | First Ubuntu with KF6/Qt6 packages |
| Debian Trixie | \`.deb\` | amd64, arm64 | |
| Fedora 42 | \`.rpm\` | amd64, arm64 | |
| openSUSE Tumbleweed | \`.rpm\` | amd64, arm64 | Install with \`zypper --no-gpg-checks install\` (unsigned package) |

**6 packages per release** (2 architectures × 3 distros).

## How it works

1. Push a \`v*.*.*\` tag → six build jobs run in parallel (one container per distro/arch combination) → packages are attached to a GitHub Release
2. After build, a validation job installs each package and confirms \`krunner_translator.so\` and \`kcm_krunner_translator.so\` land in the correct KDE paths, and that \`ldd\` reports no missing libraries
3. \`workflow_dispatch\` → same pipeline but release is created as a **draft** (useful for testing without a real tag)

## Packages install the plugin to the correct KDE path

Verified in Docker containers:
- \`krunner_translator.so\` → \`kf6/krunner/\`
- \`kcm_krunner_translator.so\` → \`kf6/krunner/kcms/\`

## Notes

- Packages are **not GPG-signed** (standard for CPack CI builds). openSUSE users need \`zypper --no-gpg-checks install <file>.rpm\`
- Only Qt6/KF6 (Plasma 6) is supported — matches the current codebase
- \`translate-shell\` (\`trans\`) is listed as a \`Recommends\` (DEB) / soft dependency (RPM) rather than a hard build dependency — it is a runtime requirement for the Google/Bing engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)