### PR TITLE
Fix segfaults from invalid language input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,10 +69,25 @@ set(test_dependencies
         src/language/LanguageRepository.cpp
         src/language/Language.cpp
         )
+
+set(parser_test_dependencies
+        src/Parser.cpp
+        src/TranslationQuery.cpp
+        src/language/LanguageRepository.cpp
+        src/language/Language.cpp
+        )
+
 add_executable(translator_test test/TranslateShellProcessTest.cpp ${test_dependencies})
 add_test(NAME translator_test COMMAND translator_test)
-
 target_link_libraries(translator_test PRIVATE Qt6::Test)
+
+add_executable(parser_test test/ParserTest.cpp ${parser_test_dependencies})
+add_test(NAME parser_test COMMAND parser_test)
+target_link_libraries(parser_test PRIVATE Qt6::Test)
+
+add_executable(language_repository_test test/LanguageRepositoryTest.cpp src/language/LanguageRepository.cpp src/language/Language.cpp)
+add_test(NAME language_repository_test COMMAND language_repository_test)
+target_link_libraries(language_repository_test PRIVATE Qt6::Test)
 
 # ── Packaging (CPack) ──────────────────────────────────────────────────────────
 set(CPACK_PACKAGE_NAME "krunner-translator")

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -22,7 +22,7 @@ TranslationQuery* Parser::parse(const QString &term) {
         query->setSourceLanguage(sourceLanguage);
         query->setTargetLanguage(targetLanguage);
     } else {
-        // TODO: Set source Language;
+        query->setSourceLanguage(SupportedLanguage::INVALID);
         SupportedLanguage targetLanguage = repository->getSupportedLanguage(languageTerm);
         query->setTargetLanguage(targetLanguage);
     }

--- a/src/Translator.cpp
+++ b/src/Translator.cpp
@@ -54,8 +54,14 @@ void Translator::match(KRunner::RunnerContext &context) {
     const QString term = context.query();
     TranslationQuery * query = parser.parse(term);
     query->updateSourceLanguage(defaultLanguage, alternativeDefaultLanguage);
-    if(!query->isValid()) return;
-    if (!context.isValid()) return;
+    if(!query->isValid()) {
+        delete query;
+        return;
+    }
+    if (!context.isValid()) {
+        delete query;
+        return;
+    }
 
     if (m_baiduEnable) {
         QEventLoop baiduLoop;

--- a/src/language/LanguageRepository.cpp
+++ b/src/language/LanguageRepository.cpp
@@ -152,11 +152,19 @@ QString LanguageRepository::getCombinedName(QString abbreviation) {
 }
 
 SupportedLanguage LanguageRepository::getSupportedLanguage(QString abbr) {
-    return abbrMap->find(abbr).value();
+    auto it = abbrMap->find(abbr);
+    if (it == abbrMap->end()) {
+        return SupportedLanguage::INVALID;
+    }
+    return it.value();
 }
 
 QString LanguageRepository::getAbbreviation(SupportedLanguage language) const {
-    return supportedLanguages->find(language).value().getAbbreviation();
+    auto it = supportedLanguages->find(language);
+    if (it == supportedLanguages->end()) {
+        return QString();
+    }
+    return it.value().getAbbreviation();
 }
 
 bool LanguageRepository::containsAbbreviation(QString abbreviation) {

--- a/test/LanguageRepositoryTest.cpp
+++ b/test/LanguageRepositoryTest.cpp
@@ -1,0 +1,29 @@
+#include "LanguageRepositoryTest.h"
+
+void LanguageRepositoryTest::initTestCase() {
+    repository.initialize();
+}
+
+void LanguageRepositoryTest::testGetSupportedLanguageValid() {
+    SupportedLanguage lang = repository.getSupportedLanguage(QStringLiteral("de"));
+    QCOMPARE(lang, SupportedLanguage::German);
+}
+
+void LanguageRepositoryTest::testGetSupportedLanguageInvalid() {
+    SupportedLanguage lang = repository.getSupportedLanguage(QStringLiteral("xyz"));
+    QCOMPARE(lang, SupportedLanguage::INVALID);
+}
+
+void LanguageRepositoryTest::testGetAbbreviationValid() {
+    QString abbr = repository.getAbbreviation(SupportedLanguage::German);
+    QCOMPARE(abbr, QStringLiteral("de"));
+}
+
+void LanguageRepositoryTest::testGetAbbreviationInvalid() {
+    QString abbr = repository.getAbbreviation(SupportedLanguage::INVALID);
+    QVERIFY(abbr.isEmpty());
+}
+
+QTEST_MAIN(LanguageRepositoryTest)
+
+#include "LanguageRepositoryTest.moc"

--- a/test/LanguageRepositoryTest.h
+++ b/test/LanguageRepositoryTest.h
@@ -1,0 +1,25 @@
+#ifndef RUNNERTRANSLATOR_LANGUAGEREPOSITORYTEST_H
+#define RUNNERTRANSLATOR_LANGUAGEREPOSITORYTEST_H
+
+#include <QtTest/QtTest>
+#include <QtCore/QObject>
+#include "../src/language/LanguageRepository.h"
+
+class LanguageRepositoryTest : public QObject {
+
+Q_OBJECT;
+
+    LanguageRepository repository;
+
+private Q_SLOTS:
+
+    void initTestCase();
+
+    void testGetSupportedLanguageValid();
+    void testGetSupportedLanguageInvalid();
+    void testGetAbbreviationValid();
+    void testGetAbbreviationInvalid();
+
+};
+
+#endif

--- a/test/ParserTest.cpp
+++ b/test/ParserTest.cpp
@@ -40,6 +40,26 @@ void ParserTest::testInvalidSourceTargetLanguage() {
     delete query;
 }
 
+void ParserTest::testIssue34InvalidSingleLanguageReproducer() {
+    TranslationQuery *query = parser.parse(QStringLiteral("deeeee e"));
+    QVERIFY(query != nullptr);
+    query->updateSourceLanguage(SupportedLanguage::English, SupportedLanguage::Spanish);
+    QCOMPARE(query->getSourceAbbreviation(), QStringLiteral("en"));
+    QVERIFY(query->getTargetAbbreviation().isEmpty());
+    QVERIFY(!query->isValid());
+    delete query;
+}
+
+void ParserTest::testIssue34InvalidSourceTargetReproducer() {
+    TranslationQuery *query = parser.parse(QStringLiteral("abc-abc a"));
+    QVERIFY(query != nullptr);
+    query->updateSourceLanguage(SupportedLanguage::English, SupportedLanguage::Spanish);
+    QCOMPARE(query->getSourceAbbreviation(), QStringLiteral("en"));
+    QVERIFY(query->getTargetAbbreviation().isEmpty());
+    QVERIFY(!query->isValid());
+    delete query;
+}
+
 void ParserTest::testEmptyQuery() {
     TranslationQuery *query = parser.parse(QStringLiteral(""));
     QVERIFY(query != nullptr);

--- a/test/ParserTest.cpp
+++ b/test/ParserTest.cpp
@@ -1,0 +1,59 @@
+#include "ParserTest.h"
+
+void ParserTest::initTestCase() {
+    repository.initialize();
+    parser.setRepository(&repository);
+}
+
+void ParserTest::testValidSingleLanguage() {
+    TranslationQuery *query = parser.parse(QStringLiteral("de Hallo"));
+    QVERIFY(query != nullptr);
+    QCOMPARE(query->getText(), QStringLiteral("Hallo"));
+    QCOMPARE(query->getTargetAbbreviation(), QStringLiteral("de"));
+    QVERIFY(!query->isValid());
+    delete query;
+}
+
+void ParserTest::testValidSourceTargetLanguage() {
+    TranslationQuery *query = parser.parse(QStringLiteral("en-de Hello"));
+    QVERIFY(query != nullptr);
+    QCOMPARE(query->getText(), QStringLiteral("Hello"));
+    QCOMPARE(query->getSourceAbbreviation(), QStringLiteral("en"));
+    QCOMPARE(query->getTargetAbbreviation(), QStringLiteral("de"));
+    QVERIFY(query->isValid());
+    delete query;
+}
+
+void ParserTest::testInvalidLanguageAbbreviation() {
+    TranslationQuery *query = parser.parse(QStringLiteral("xyz hello"));
+    QVERIFY(query != nullptr);
+    QCOMPARE(query->getText(), QStringLiteral("hello"));
+    QVERIFY(!query->isValid());
+    delete query;
+}
+
+void ParserTest::testInvalidSourceTargetLanguage() {
+    TranslationQuery *query = parser.parse(QStringLiteral("abc-xyz hello"));
+    QVERIFY(query != nullptr);
+    QCOMPARE(query->getText(), QStringLiteral("hello"));
+    QVERIFY(!query->isValid());
+    delete query;
+}
+
+void ParserTest::testEmptyQuery() {
+    TranslationQuery *query = parser.parse(QStringLiteral(""));
+    QVERIFY(query != nullptr);
+    QVERIFY(!query->isValid());
+    delete query;
+}
+
+void ParserTest::testNoSpaceInQuery() {
+    TranslationQuery *query = parser.parse(QStringLiteral("de"));
+    QVERIFY(query != nullptr);
+    QVERIFY(!query->isValid());
+    delete query;
+}
+
+QTEST_MAIN(ParserTest)
+
+#include "ParserTest.moc"

--- a/test/ParserTest.h
+++ b/test/ParserTest.h
@@ -21,6 +21,8 @@ private Q_SLOTS:
     void testValidSourceTargetLanguage();
     void testInvalidLanguageAbbreviation();
     void testInvalidSourceTargetLanguage();
+    void testIssue34InvalidSingleLanguageReproducer();
+    void testIssue34InvalidSourceTargetReproducer();
     void testEmptyQuery();
     void testNoSpaceInQuery();
 

--- a/test/ParserTest.h
+++ b/test/ParserTest.h
@@ -1,0 +1,29 @@
+#ifndef RUNNERTRANSLATOR_PARSERTEST_H
+#define RUNNERTRANSLATOR_PARSERTEST_H
+
+#include <QtTest/QtTest>
+#include <QtCore/QObject>
+#include "../src/Parser.h"
+#include "src/language/LanguageRepository.h"
+
+class ParserTest : public QObject {
+
+Q_OBJECT;
+
+    Parser parser;
+    LanguageRepository repository;
+
+private Q_SLOTS:
+
+    void initTestCase();
+
+    void testValidSingleLanguage();
+    void testValidSourceTargetLanguage();
+    void testInvalidLanguageAbbreviation();
+    void testInvalidSourceTargetLanguage();
+    void testEmptyQuery();
+    void testNoSpaceInQuery();
+
+};
+
+#endif


### PR DESCRIPTION
Fixes #34

Adds validation to prevent segfaults when:
- Invalid language codes are entered (e.g., `deeeee e`)
- Invalid source-target pairs are entered (e.g., `abc-abc a`)

The parser now properly handles missing/invalid language lookups.